### PR TITLE
Safe naming for the fields

### DIFF
--- a/front/py2pydantic.py
+++ b/front/py2pydantic.py
@@ -62,7 +62,9 @@ class Config:
         alias_generator = remove_final_underscore
 
 def func_to_pyd_input_model_cls(func: Callable, dflt_type=Any, name=None):
-    """Get a pydantic model of the arguments of a python function"""
+    """Get a pydantic model of the arguments of a python function
+    with safe naming for the fields
+    """
     name = name or name_of_obj(func)
     d = dict(func_to_pyd_model_specs(func, dflt_type))
     d =  {append_underscore(k): v for k, v in d.items()}


### PR DESCRIPTION
Field names (for the Pydantic model) that might conflict with BaseModel names (for example 'copy') are modified with a trailing underscore and then accessed under their original form via an alias. 
Under the hood, I might have Mymodel('copy_'=True),  but in reality I can declare it as Mymodel('copy'=True) because the field 'copy_' has somewhere an alias declaration 'alias = 'copy''